### PR TITLE
исправлено: лишние ресурсы

### DIFF
--- a/api/core/utils/s_update_res.php
+++ b/api/core/utils/s_update_res.php
@@ -28,10 +28,18 @@ function s_update_res ( $id ) {
                             $resources[$income_key]['count'] = $resources[$income_key]['count'] + $units;
                             $resources[$income_key]['time'] = $resources[$income_key]['time'] + $units * $resources_unit_time;
                         }
+                        $resources[$income_key]['update'] = true;
                     }
                 }
             }
         }
+    }
+
+    foreach ( $resources as $key => $value ) {
+        if ( !isset($value['update']) ) {
+            $resources[$key]['time'] = $_SERVER['REQUEST_TIME'];
+        }
+        unset( $resources[$key]['update'] );
     }
 
     db_custom_no_return( "UPDATE `bases` SET `resources` = ? WHERE `id` = ?",


### PR DESCRIPTION
Допустим, у нас нет построек, которые дают воду, и вот мы построили ее. Тогда нам дастся то количество ресурсов, которое должно, а то, которое мы получили бы если постройка продолжала давать доход с момента последнего обновления.